### PR TITLE
Increase tests coverage to 60%

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -48,4 +48,4 @@ Please check the type of change your PR introduces:
 ## Other information
 
 <!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
-<!-- This document was adapted from the open-source [appium/appium](https://github.com/appium/appium/blob/main/.github/PULL_REQUEST_TEMPLATE.md) repository. -->
+<!-- This document was adapted from the open-source [appium/appium](https://github.com/appium/appium/blob/master/.github/PULL_REQUEST_TEMPLATE.md) repository. -->

--- a/.run/ghacu.run.xml
+++ b/.run/ghacu.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="ghacu" type="DotNetProject" factoryName=".NET Project">
     <option name="EXE_PATH" value="$PROJECT_DIR$/src/Ghacu.Runner/bin/Debug/netcoreapp5.0/ghacu.dll" />
-    <option name="PROGRAM_PARAMETERS" value="--repository $PROJECT_DIR$ --log-level Error --upgrade" />
+    <option name="PROGRAM_PARAMETERS" value="--repository $PROJECT_DIR$ --log-level Error" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/src/Ghacu.Runner/bin/Debug/netcoreapp5.0" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />

--- a/README.md
+++ b/README.md
@@ -74,6 +74,3 @@ docker run --rm -i -v "$PWD:/work" amake/innosetup inno/ghacu-win-{x64|x86}.iss
 2. Open `inno\ghacu-win-{x64|x86}.iss` file with _Inno Setup_.
 3. Increase version.
 4. Run _Build_ -> _Compile_.
-## Troubleshooting
-### API rate limit exceeded for...
-If you see such message it means that you [exceeded limit](https://developer.github.com/v3/#rate-limiting) of requests as unauthenticated user. For authenticated users rate limit is much bigger, so to solve this problem you need to pass GitHub token to _ghacu_. More information [here](#github-token).

--- a/build.ps1
+++ b/build.ps1
@@ -28,8 +28,7 @@ function Compress-Package {
   Set-Location ..
 }
 
-$xml = [xml](Get-Content src/Ghacu.Runner/Ghacu.Runner.csproj)
-$version = $xml.Project.PropertyGroup.PackageVersion
+$version = $env:GHACU_VERSION
 
 switch($os) {
   {($_ -eq "macos-latest") -Or ($_ -eq "")} {

--- a/src/Ghacu.Api/Entities/Version.cs
+++ b/src/Ghacu.Api/Entities/Version.cs
@@ -26,7 +26,8 @@ namespace Ghacu.Api.Entities
 
       try
       {
-        return ToSemVersion().CompareTo(other.ToSemVersion());
+        int result = ToSemVersion().CompareTo(other.ToSemVersion());
+        return result == 0 ? string.Compare(Value, other.Value, StringComparison.Ordinal) : result;
       }
       catch (Exception)
       {

--- a/src/Ghacu.Api/Entities/WorkflowFile.cs
+++ b/src/Ghacu.Api/Entities/WorkflowFile.cs
@@ -14,6 +14,7 @@ namespace Ghacu.Api.Entities
       get
       {
         int index = FilePath?.IndexOf(".github", StringComparison.Ordinal) ?? -1;
+        // ReSharper disable once PossibleNullReferenceException
         return index < 0 ? string.Empty : FilePath.Substring(index);
       }
     }

--- a/src/Ghacu.Api/Entities/WorkflowInfo.cs
+++ b/src/Ghacu.Api/Entities/WorkflowInfo.cs
@@ -16,6 +16,11 @@ namespace Ghacu.Api.Entities
 
     public void Upgrade()
     {
+      if (string.IsNullOrWhiteSpace(File.FilePath) || !System.IO.File.Exists(File.FilePath))
+      {
+        return;
+      }
+
       string content = System.IO.File.ReadAllText(File.FilePath);
       foreach (Action action in Workflow.Jobs.Values
         .SelectMany(job => job.Steps)
@@ -24,11 +29,10 @@ namespace Ghacu.Api.Entities
         .Distinct())
       {
         string delimiter = action.Type == UsesType.Docker ? ":" : "@";
-        string prefix = action.Type == UsesType.Docker ? "docker://" : string.Empty;
         content = Regex.Replace(
           content,
-          $"(.*)({action.FullName}{delimiter}.+[ \t]*)(\n.*)",
-          $"$1{prefix}{action.FullName}{delimiter}{action.LatestVersion}$3");
+          $"(.*)({action.FullName}{delimiter}.+[ \t]*)(.*)",
+          $"$1{action.FullName}{delimiter}{action.LatestVersion}$3");
       }
 
       System.IO.File.WriteAllText(File.FilePath, content);

--- a/src/Ghacu.Api/IGlobalConfig.cs
+++ b/src/Ghacu.Api/IGlobalConfig.cs
@@ -2,7 +2,6 @@ namespace Ghacu.Api
 {
   public interface IGlobalConfig
   {
-    public string GitHubToken { get; }
     public bool UseCache { get; }
   }
 }

--- a/src/Ghacu.GitHub/GitHubClient.cs
+++ b/src/Ghacu.GitHub/GitHubClient.cs
@@ -1,81 +1,26 @@
-using System;
 using System.Linq;
 using System.Threading.Tasks;
-using Ghacu.Api;
-using Ghacu.GitHub.Exceptions;
-using Microsoft.Extensions.Logging;
 using Octokit;
-using OctokitClient = Octokit.GitHubClient;
 
 namespace Ghacu.GitHub
 {
-  public sealed class GitHubClient : ILatestVersionProvider
+  public class GitHubClient : IGitHubClient
   {
-    private const string ENV_GITHUB_TOKEN = "GHACU_GITHUB_TOKEN";
-    private const string APP_NAME = "ghacu";
-    private readonly IGlobalConfig _globalConfig;
-    private readonly ILogger<GitHubClient> _logger;
-    private OctokitClient _client;
+    private readonly Octokit.GitHubClient _client;
 
-    public GitHubClient(ILoggerFactory loggerFactory, IGlobalConfig globalConfig)
+    public GitHubClient(string appName, string token)
     {
-      _logger = loggerFactory.CreateLogger<GitHubClient>();
-      _globalConfig = globalConfig;
+      _client = new Octokit.GitHubClient(new ProductHeaderValue(appName));
+      if (token != null)
+      {
+        _client.Credentials = new Credentials(token);
+      }
     }
+    
+    public Task<string> GetLatestReleaseVersionAsync(string owner, string name) =>
+      _client.Repository.Release.GetLatest(owner, name).ContinueWith(t => t.Result.TagName);
 
-    public async Task<string> GetLatestVersionAsync(string owner, string repository)
-    {
-      _client ??= CreateGitHubClient();
-      Exception lastException = null;
-      string tagName = null;
-      try
-      {
-        _logger.LogInformation($"Getting latest release for {owner}/{repository}...");
-        tagName = (await _client.Repository.Release.GetLatest(owner, repository)).TagName;
-      }
-      catch (NotFoundException)
-      {
-        try
-        {
-          _logger.LogInformation($"{owner}/{repository} release is not found. Getting latest tag...");
-          tagName = (await _client.Repository.GetAllTags(owner, repository)).LastOrDefault()?.Name;
-        }
-        catch (Exception e)
-        {
-          lastException = e;
-        }
-      }
-      catch (Exception e)
-      {
-        lastException = e;
-      }
-
-      string errorMessage = $"{owner}/{repository} version is not found.";
-      if (lastException != null)
-      {
-        _logger.LogError(lastException, lastException.Message);
-        throw new GitHubVersionNotFoundException(errorMessage, lastException);
-      }
-
-      if (tagName == null)
-      {
-        throw new GitHubVersionNotFoundException(errorMessage);
-      }
-
-      _logger.LogInformation($"{owner}/{repository} latest release is {tagName}");
-      return tagName;
-    }
-
-    private OctokitClient CreateGitHubClient()
-    {
-      var gitHubClient = new OctokitClient(new ProductHeaderValue(APP_NAME));
-      string gitHubToken = _globalConfig.GitHubToken ?? Environment.GetEnvironmentVariable(ENV_GITHUB_TOKEN);
-      if (gitHubToken != null)
-      {
-        gitHubClient.Credentials = new Credentials(gitHubToken);
-      }
-
-      return gitHubClient;
-    }
+    public Task<string> GetLatestTagVersionAsync(string owner, string name) =>
+      _client.Repository.GetAllTags(owner, name).ContinueWith(t => t.Result.LastOrDefault()?.Name);
   }
 }

--- a/src/Ghacu.GitHub/GitHubVersionProvider.cs
+++ b/src/Ghacu.GitHub/GitHubVersionProvider.cs
@@ -1,0 +1,64 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Ghacu.Api;
+using Ghacu.GitHub.Exceptions;
+using Microsoft.Extensions.Logging;
+using Octokit;
+
+namespace Ghacu.GitHub
+{
+  public sealed class GitHubVersionProvider : ILatestVersionProvider
+  {
+    private readonly ILogger<GitHubVersionProvider> _logger;
+    private readonly IGitHubClient _client;
+
+    public GitHubVersionProvider(ILoggerFactory loggerFactory, IGitHubClient client)
+    {
+      _logger = loggerFactory.CreateLogger<GitHubVersionProvider>();
+      _client = client;
+    }
+
+    public async Task<string> GetLatestVersionAsync(string owner, string repository)
+    {
+      Exception lastException = null;
+      string tagName = null;
+      try
+      {
+        _logger.LogInformation($"Getting latest release for {owner}/{repository}...");
+        tagName = await _client.GetLatestReleaseVersionAsync(owner, repository);
+      }
+      catch (NotFoundException)
+      {
+        try
+        {
+          _logger.LogInformation($"{owner}/{repository} release is not found. Getting latest tag...");
+          tagName = await _client.GetLatestTagVersionAsync(owner, repository);
+        }
+        catch (Exception e)
+        {
+          lastException = e;
+        }
+      }
+      catch (Exception e)
+      {
+        lastException = e;
+      }
+
+      string errorMessage = $"{owner}/{repository} version is not found.";
+      if (lastException != null)
+      {
+        _logger.LogError(lastException, lastException.Message);
+        throw new GitHubVersionNotFoundException(errorMessage, lastException);
+      }
+
+      if (tagName == null)
+      {
+        throw new GitHubVersionNotFoundException(errorMessage);
+      }
+
+      _logger.LogInformation($"{owner}/{repository} latest release is {tagName}");
+      return tagName;
+    }
+  }
+}

--- a/src/Ghacu.GitHub/GitHubVersionProvider.cs
+++ b/src/Ghacu.GitHub/GitHubVersionProvider.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Threading.Tasks;
 using Ghacu.Api;
 using Ghacu.GitHub.Exceptions;

--- a/src/Ghacu.GitHub/IGitHubClient.cs
+++ b/src/Ghacu.GitHub/IGitHubClient.cs
@@ -1,6 +1,4 @@
-using System.Collections.Generic;
 using System.Threading.Tasks;
-using Octokit;
 
 namespace Ghacu.GitHub
 {

--- a/src/Ghacu.GitHub/IGitHubClient.cs
+++ b/src/Ghacu.GitHub/IGitHubClient.cs
@@ -1,0 +1,12 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Octokit;
+
+namespace Ghacu.GitHub
+{
+  public interface IGitHubClient
+  {
+    Task<string> GetLatestReleaseVersionAsync(string owner, string name);
+    Task<string> GetLatestTagVersionAsync(string owner, string name);
+  }
+}

--- a/src/Ghacu.Runner/Cli/CliService.cs
+++ b/src/Ghacu.Runner/Cli/CliService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using Ghacu.Api.Entities;
 using Ghacu.GitHub;
-using Ghacu.GitHub.Exceptions;
 using Ghacu.Runner.Cli.Print;
 using Ghacu.Workflow;
 using Ghacu.Workflow.Exceptions;

--- a/src/Ghacu.Runner/Cli/Print/ActionPrinterBase.cs
+++ b/src/Ghacu.Runner/Cli/Print/ActionPrinterBase.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using Ghacu.Api.Entities;
 using Action = Ghacu.Api.Entities.Action;
 
 namespace Ghacu.Runner.Cli.Print

--- a/src/Ghacu.Runner/GlobalConfig.cs
+++ b/src/Ghacu.Runner/GlobalConfig.cs
@@ -4,13 +4,11 @@ namespace Ghacu.Runner
 {
   public class GlobalConfig : IGlobalConfig
   {
-    public GlobalConfig(string token, bool useCache)
+    public GlobalConfig(bool useCache)
     {
-      GitHubToken = token;
       UseCache = useCache;
     }
 
-    public string GitHubToken { get; }
     public bool UseCache { get; }
   }
 }

--- a/src/Ghacu.Workflow/Exceptions/WorkflowException.cs
+++ b/src/Ghacu.Workflow/Exceptions/WorkflowException.cs
@@ -4,7 +4,7 @@ namespace Ghacu.Workflow.Exceptions
 {
   public abstract class WorkflowException : Exception
   {
-    public WorkflowException(string message) : base(message)
+    protected WorkflowException(string message) : base(message)
     {
     }
   }

--- a/tests/Ghacu.Api.Tests/Entities/VersionTest.cs
+++ b/tests/Ghacu.Api.Tests/Entities/VersionTest.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using Xunit;
+using Version = Ghacu.Api.Entities.Version;
+
+namespace Ghacu.Api.Tests.Entities
+{
+  public class VersionTest
+  {
+    [Theory]
+    [InlineData("v45.3.0-beta.3+8908")]
+    [InlineData("45.3.0-beta.3+8908")]
+    public void ToSemVersion_Valid(string v)
+    {
+      var version = new Version(v).ToSemVersion();
+      Assert.Equal(45, version.Major);
+      Assert.Equal(3, version.Minor);
+      Assert.Equal(0, version.Patch);
+      Assert.Equal("beta.3", version.Prerelease);
+      Assert.Equal("8908", version.Build);
+    }
+    
+    [Theory]
+    [MemberData(nameof(DataToSemVersionInvalid))]
+    public void ToSemVersion_Invalid(string v, Type exceptionType) =>
+      Assert.Throws(exceptionType, () => new Version(v).ToSemVersion());
+
+    public static IEnumerable<object[]> DataToSemVersionInvalid() => new List<object[]>
+    {
+      new object[] { null, typeof(ArgumentNullException) },
+      new object[] { "vInvalid", typeof(ArgumentException) },
+      new object[] { "Invalid", typeof(ArgumentException) }
+    };
+
+    [Theory]
+    [MemberData(nameof(DataCompareToAllCases))]
+    public void CompareTo_AllCases(Version v1, Version v2, int expected) =>
+      Assert.Equal(expected, v1.CompareTo(v2));
+
+    public static IEnumerable<object[]> DataCompareToAllCases()
+    {
+      var v1 = new Version("v1.1.1-preview.5+56");
+      return new List<object[]>
+      {
+        // Same by reference
+        new object[] { v1, v1, 0 },
+        new object[] { v1, null, 1 },
+        // Same by value
+        new object[] { v1, new Version("v1.1.1-preview.5+56"), 0 },
+        // Major
+        new object[] { v1, new Version("v2.1.1"), -1 },
+        new object[] { v1, new Version("v0.1.1"), 1 },
+        // Minor
+        new object[] { v1, new Version("v1.2.1"), -1 },
+        new object[] { v1, new Version("v1.0.1"), 1 },
+        // Patch
+        new object[] { v1, new Version("v1.1.2"), -1 },
+        new object[] { v1, new Version("v1.1.0"), 1 },
+        // Prerelease
+        new object[] { v1, new Version("v1.1.1-preview.6"), -1 },
+        new object[] { v1, new Version("v1.1.1-preview.4"), 1 },
+        // Build
+        new object[] { v1, new Version("v1.1.1-preview.5+57"), -1 },
+        new object[] { v1, new Version("v1.1.1-preview.5+55"), 1 },
+        // Invalid
+        new object[] { new Version("not-valid-1"), new Version("not-valid-1"), 0 },
+        new object[] { new Version("not-valid-1"), new Version("not-valid-2"), -1 },
+        new object[] { new Version("not-valid-2"), new Version("not-valid-1"), 1 },
+      };
+    }
+  }
+}

--- a/tests/Ghacu.Api.Tests/Entities/WorkflowInfoTest.cs
+++ b/tests/Ghacu.Api.Tests/Entities/WorkflowInfoTest.cs
@@ -1,0 +1,163 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using Ghacu.Api.Entities;
+using Xunit;
+
+namespace Ghacu.Api.Tests.Entities
+{
+  public class WorkflowInfoTest
+  {
+    [Fact]
+    public void Test_GettersSetters()
+    {
+      const string file = "test-file";
+      var actionWorkflow = new ActionWorkflow();
+      var wfi = new WorkflowInfo(file, actionWorkflow);
+      Assert.NotNull(wfi.File);
+      Assert.Equal(file, wfi.File.FilePath);
+      Assert.Same(actionWorkflow, wfi.Workflow);
+    }
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("      ")]
+    [InlineData("non-existing-path")]
+    public void Upgrade_InvalidFile(string file) => new WorkflowInfo(file, null).Upgrade();
+
+    [Theory]
+    [InlineData(
+      new[] { "v1", "v1", "v1", "v1", "v1", "v1", "v1" },
+      new[] { "v2", "v1.1", "v1.0.1", "unknown", "latest", "v1.0.1-preview.7", "v1.0.1-preview.6+57" },
+      new[] { "v2", "v1.1", "v1.0.1", "v1", "v1", "v1.0.1-preview.7", "v1.0.1-preview.6+57" })]
+    [InlineData(
+      new[] { "v1", "v1", "v1", "v1", "v1", "v1", "v1" },
+      new[] { "v1.0", "v1.0.0", "v1.0.0-alpha.1", "v1.0.0-alpha.1+6574", "v1.0-alpha.1", "v1-alpha.1+6574", "v1" },
+      new[] { "v1.0", "v1.0.0", "v1", "v1", "v1", "v1", "v1" })]
+    [InlineData(
+      new[] { "v1.1", "v1.1", "v1.1", "v1.1", "v1.1", "v1.1", "v1.1" },
+      new[] { "v2", "v1.2", "v1.1.1", "v1.1.1-preview.7", "v1.1.1-preview.6+57", "v1.1-preview.7", "v1-preview.6+57" },
+      new[] { "v2", "v1.2", "v1.1.1", "v1.1.1-preview.7", "v1.1.1-preview.6+57", "v1.1", "v1.1" })]
+    [InlineData(
+      new[] { "v1.1", "v1.1", "v1.1", "v1.1", "v1.1", "v1.1", "v1.1" },
+      new[] { "v1.1.0", "v1.1.1-alpha.1", "v1.1.1-alpha.1+3457", "v1.1", "v1", "v1.0-preview.7", "v1.0" },
+      new[] { "v1.1.0", "v1.1.1-alpha.1", "v1.1.1-alpha.1+3457", "v1.1", "v1.1", "v1.1", "v1.1" })]
+    [InlineData(
+      new[] { "v1.1", "v1.1", "v1.1", "v1.1", "v1.1", "v1.1", "v1.1" },
+      new[] { "v1.0", "v0.2", "v1.1-alpha.1+3457", "v0.0.2", "unknown", "v1.0-preview.7", "latest" },
+      new[] { "v1.1", "v1.1", "v1.1", "v1.1", "v1.1", "v1.1", "v1.1" })]
+    [InlineData(
+      new[] { "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1" },
+      new[] { "v2", "v1.2", "v1.1.2", "v1.1.1-preview.7", "v1.1.1-preview.6+57", "v1.1-preview.7", "v1-preview.6+57" },
+      new[] { "v2", "v1.2", "v1.1.2", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1" })]
+    [InlineData(
+      new[] { "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1" },
+      new[] { "v1.1.1", "v1.1.0-alpha.1", "v1.1.0-alpha.1+2362", "v1.1-beta.1", "v1-preview.6", "v1.1.0", "v1.0.2" },
+      new[] { "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1" })]
+    [InlineData(
+      new[] { "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1" },
+      new[] { "v1.2.1", "v2.0.1", "v0.2.2", "v0.2.2-beta.1", "v1.0.2-preview.6", "latest", "unknown" },
+      new[] { "v1.2.1", "v2.0.1", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1", "v1.1.1" })]
+    [InlineData(
+      new[] { "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2" },
+      new[] { "v1", "v1.1", "v1.1.1", "v1.1.1-alpha.2", "v1.1.1-alpha.2+3743", "latest", "uknown" },
+      new[] { "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1", "v1.1.1-alpha.2", "v1.1.1-alpha.2+3743", "v1.1.1-alpha.2", "v1.1.1-alpha.2" })]
+    [InlineData(
+      new[] { "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2" },
+      new[] { "v1.0", "v1.1.0", "v1.1.1-alpha.1", "v1.1.1-beta.1", "v1.1.1-alpha.1+3743", "v1.0.5", "v1.1.1-alpha.3" },
+      new[] { "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-beta.1", "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.3" })]
+    [InlineData(
+      new[] { "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2", "v1.1.1-alpha.2" },
+      new[] { "v2", "v2.0", "v2.0.0", "v1.2", "v1.2.0", "v1.1.2", "v0.2.2-beta.1" },
+      new[] { "v2", "v2.0", "v2.0.0", "v1.2", "v1.2.0", "v1.1.2", "v1.1.1-alpha.2" })]
+    [InlineData(
+      new[] { "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233" },
+      new[] { "v1", "v1.1", "v1.1.1", "v1.1.1-alpha.2", "v1.1.1-alpha.2+3743", "latest", "uknown" },
+      new[] { "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3743", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233" })]
+    [InlineData(
+      new[] { "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233" },
+      new[] { "v1.0", "v1.1.0", "v1.1.1-alpha.1", "v1.1.1-beta.1", "v1.1.1-alpha.1+3743", "v1.0.5", "v1.1.1-alpha.3" },
+      new[] { "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-beta.1", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.3" })]
+    [InlineData(
+      new[] { "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233", "v1.1.1-alpha.2+3233" },
+      new[] { "v2", "v2.0", "v2.0.0", "v1.2", "v1.2.0", "v1.1.2", "v0.2.2-beta.1" },
+      new[] { "v2", "v2.0", "v2.0.0", "v1.2", "v1.2.0", "v1.1.2", "v1.1.1-alpha.2+3233" })]
+    [InlineData(
+      new[] { "v1.1.1-alpha.2+3233", "latest", "latest", "latest", "latest", "latest", "latest" },
+      new[] { "v1.1.1-alpha.2+3232", "v0.0.1", "v0.1", "v1", "v0.0.0-alpha.1", "v0.0.0-alpha.1+1", "latest" },
+      new[] { "v1.1.1-alpha.2+3233", "v0.0.1", "v0.1", "v1", "v0.0.0-alpha.1", "v0.0.0-alpha.1+1", "latest" })]
+    public void Upgrade_FileValid(string[] current, string[] latest, string[] result)
+    {
+      var actionWorkflow = new ActionWorkflow
+      {
+        Jobs = new Dictionary<string, Job>
+        {
+          {
+            "github", new Job
+            {
+              Steps = current.Select((v, i) =>
+              {
+                var step = new Step { Uses = $"own{i}/repo{i}@{v}" };
+                step.Action.LatestVersion = latest[i];
+                return step;
+              })
+            }
+          },
+          {
+            "docker", new Job
+            {
+              Steps = current.Select((v, i) =>
+              {
+                var step = new Step { Uses = $"docker://d{i}.com:{v}" };
+                step.Action.LatestVersion = latest[i];
+                return step;
+              })
+            }
+          }
+        }
+      };
+      var original = @"
+name: Test
+jobs:
+  github:
+    steps:
+";
+      original += string.Join("\n", current.Select(
+        (v, i) => $"      uses: own{i}/repo{i}@{v}"));
+      original += @"
+  docker:
+    steps:
+";
+      original += string.Join("\n", current.Select(
+        (v, i) => $"      uses: docker://d{i}.com:{v}"));
+      var expected = @"
+name: Test
+jobs:
+  github:
+    steps:
+";
+      expected += string.Join("\n", result.Select(
+        (v, i) => $"      uses: own{i}/repo{i}@{v}"));
+      expected += @"
+  docker:
+    steps:
+";
+      expected += string.Join("\n", result.Select(
+        (v, i) => $"      uses: docker://d{i}.com:{v}"));
+      const string file = "./test.yml";
+      File.WriteAllText(file, original);
+      try
+      {
+        var wfi = new WorkflowInfo(file, actionWorkflow);
+        wfi.Upgrade();
+        Assert.Equal(expected, File.ReadAllText(file));
+      }
+      finally
+      {
+        File.Delete(file);
+      }
+    }
+  }
+}

--- a/tests/Ghacu.GitHub.Tests/GitHubVersionProviderTest.cs
+++ b/tests/Ghacu.GitHub.Tests/GitHubVersionProviderTest.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Net;
+using Ghacu.GitHub.Exceptions;
+using Microsoft.Extensions.Logging;
+using Octokit;
+using Telerik.JustMock;
+using Xunit;
+
+namespace Ghacu.GitHub.Tests
+{
+  public class GitHubVersionProviderTest
+  {
+    [Fact]
+    public async void GetLatestVersionAsync_LatestReleaseExists()
+    {
+      const string owner = "test-owner";
+      const string repository = "test-repository";
+      const string expected = "test-version";
+      
+      var gitHubClientMock = Mock.Create<IGitHubClient>();
+      Mock.Arrange(() => gitHubClientMock.GetLatestReleaseVersionAsync(owner, repository))
+        .TaskResult(expected);
+      Mock.Arrange(() => gitHubClientMock.GetLatestTagVersionAsync(Arg.AnyString, Arg.AnyString))
+        .OccursNever();
+      
+      var provider = new GitHubVersionProvider(new LoggerFactory(), gitHubClientMock);
+      string actual = await provider.GetLatestVersionAsync(owner, repository);
+      Assert.Equal(expected, actual);
+      Mock.Assert(gitHubClientMock);
+    }
+    
+    [Fact]
+    public async void GetLatestVersionAsync_LatestReleaseIsNull()
+    {
+      const string owner = "test-owner";
+      const string repository = "test-repository";
+      
+      var gitHubClientMock = Mock.Create<IGitHubClient>();
+      Mock.Arrange(() => gitHubClientMock.GetLatestReleaseVersionAsync(owner, repository))
+        .TaskResult(null);
+      Mock.Arrange(() => gitHubClientMock.GetLatestTagVersionAsync(Arg.AnyString, Arg.AnyString))
+        .OccursNever();
+      
+      var provider = new GitHubVersionProvider(new LoggerFactory(), gitHubClientMock);
+      await Assert.ThrowsAsync<GitHubVersionNotFoundException>(
+        () => provider.GetLatestVersionAsync(owner, repository));
+      Mock.Assert(gitHubClientMock);
+    }
+    
+    [Fact]
+    public async void GetLatestVersionAsync_LatestReleaseIsNotFound_LatestTagExists()
+    {
+      const string owner = "test-owner";
+      const string repository = "test-repository";
+      const string expected = "test-version";
+      
+      var gitHubClientMock = Mock.Create<IGitHubClient>();
+      Mock.Arrange(() => gitHubClientMock.GetLatestReleaseVersionAsync(owner, repository))
+        .Throws(new NotFoundException(null, HttpStatusCode.NotFound))
+        .OccursOnce();
+      Mock.Arrange(() => gitHubClientMock.GetLatestTagVersionAsync(owner, repository))
+        .TaskResult(expected);
+      
+      var provider = new GitHubVersionProvider(new LoggerFactory(), gitHubClientMock);
+      string actual = await provider.GetLatestVersionAsync(owner, repository);
+      Assert.Equal(expected, actual);
+      Mock.Assert(gitHubClientMock);
+    }
+    
+    [Fact]
+    public async void GetLatestVersionAsync_LatestReleaseIsNotFound_LatestTagIsNull()
+    {
+      const string owner = "test-owner";
+      const string repository = "test-repository";
+      
+      var gitHubClientMock = Mock.Create<IGitHubClient>();
+      Mock.Arrange(() => gitHubClientMock.GetLatestReleaseVersionAsync(owner, repository))
+        .Throws(new NotFoundException(null, HttpStatusCode.NotFound))
+        .OccursOnce();
+      Mock.Arrange(() => gitHubClientMock.GetLatestTagVersionAsync(owner, repository))
+        .TaskResult(null)
+        .OccursOnce();
+      
+      var provider = new GitHubVersionProvider(new LoggerFactory(), gitHubClientMock);
+      await Assert.ThrowsAsync<GitHubVersionNotFoundException>(
+        () => provider.GetLatestVersionAsync(owner, repository));
+      Mock.Assert(gitHubClientMock);
+    }
+
+    [Fact]
+    public async void GetLatestVersionAsync_LatestReleaseInternalError()
+    {
+      const string owner = "test-owner";
+      const string repository = "test-repository";
+      
+      var gitHubClientMock = Mock.Create<IGitHubClient>();
+      Mock.Arrange(() => gitHubClientMock.GetLatestReleaseVersionAsync(owner, repository))
+        .Throws<Exception>();
+      Mock.Arrange(() => gitHubClientMock.GetLatestTagVersionAsync(Arg.AnyString, Arg.AnyString))
+        .OccursNever();
+      
+      var provider = new GitHubVersionProvider(new LoggerFactory(), gitHubClientMock);
+      await Assert.ThrowsAsync<GitHubVersionNotFoundException>(
+        () => provider.GetLatestVersionAsync(owner, repository));
+      Mock.Assert(gitHubClientMock);
+    }
+
+    [Fact]
+    public async void GetLatestVersionAsync_LatestReleaseIsNotFound_LatestTagInternalError()
+    {
+      const string owner = "test-owner";
+      const string repository = "test-repository";
+      
+      var gitHubClientMock = Mock.Create<IGitHubClient>();
+      Mock.Arrange(() => gitHubClientMock.GetLatestReleaseVersionAsync(owner, repository))
+        .Throws(new NotFoundException(null, HttpStatusCode.NotFound))
+        .OccursOnce();
+      Mock.Arrange(() => gitHubClientMock.GetLatestTagVersionAsync(Arg.AnyString, Arg.AnyString))
+        .Throws<Exception>()
+        .OccursOnce();
+      
+      var provider = new GitHubVersionProvider(new LoggerFactory(), gitHubClientMock);
+      await Assert.ThrowsAsync<GitHubVersionNotFoundException>(
+        () => provider.GetLatestVersionAsync(owner, repository));
+      Mock.Assert(gitHubClientMock);
+    }
+  }
+}


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->
Closes #45 

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I have read the [CONTRIBUTING](https://github.com/fabasoad/ghacu/CONTRIBUTING.md) doc.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features).
- [x] Build (`dotnet build`) was run locally and any changes were pushed for failures / warnings.
- [x] Tests (`dotnet test`) has passed locally and any fixes were made for failures.

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Tests coverage < 60%

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Tests coverage > 60%

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
N/A
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- This document was adapted from the open-source [appium/appium](https://github.com/appium/appium/blob/main/.github/PULL_REQUEST_TEMPLATE.md) repository. -->
