### PR TITLE
Increase tests coverage to 70%

### DIFF
--- a/.run/ghacu.run.xml
+++ b/.run/ghacu.run.xml
@@ -1,7 +1,7 @@
 <component name="ProjectRunConfigurationManager">
   <configuration default="false" name="ghacu" type="DotNetProject" factoryName=".NET Project">
     <option name="EXE_PATH" value="$PROJECT_DIR$/src/Ghacu.Runner/bin/Debug/netcoreapp5.0/ghacu.dll" />
-    <option name="PROGRAM_PARAMETERS" value="--repository $PROJECT_DIR$ --log-level Debug --output-type Logger --color Yes" />
+    <option name="PROGRAM_PARAMETERS" value="--repository $PROJECT_DIR$" />
     <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/src/Ghacu.Runner/bin/Debug/netcoreapp5.0" />
     <option name="PASS_PARENT_ENVS" value="1" />
     <option name="USE_EXTERNAL_CONSOLE" value="0" />

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 CLI tool that checks versions of GitHub Actions that used in a repository. Please read [documentation](https://github.com/fabasoad/ghacu/wiki) for more details.
 
 ## :shipit: Commands
-```bash
+```pycon
 --no-cache     Disable cache.
 --no-colors    Disable colors.
 --log-level    (Default: Information) Set log level. Possible values: Trace, Debug, Information, Warning, Error, Critical, None.

--- a/README.md
+++ b/README.md
@@ -21,21 +21,15 @@ CLI tool that checks versions of GitHub Actions that used in a repository. Pleas
 
 ## :shipit: Commands
 ```bash
-  --cache          (Default: Yes) Enable cache.
-
-  --log-level      (Default: Error) Set log level. Possible values: Trace, Debug, Information, Warning, Error, Critical, None.
-
-  --output-type    (Default: Color) Console output type. Possible values: Color, NoColor.
-
-  --repository     Path to the root of a project.
-
-  --token          GitHub token to work with actions repositories.
-
-  --upgrade        Upgrade versions to the latest one.
-
-  --help           Display this help screen.
-
-  --version        Display version information.
+  --no-cache     (Default: false) Disable cache.
+  --no-colors    (Default: false) Disable colors.
+  --log-level    (Default: Information) Set log level. Possible values: Trace, Debug, Information, Warning, Error, Critical, None.
+  --output-type  (Default: Console) Information output type. Possible values: Console, Logger, Silent.
+  --repository   Path to the root of a project.
+  --token        GitHub token to work with actions repositories.
+  --upgrade      Upgrade versions to the latest one.
+  --help         Display this help screen.
+  --version      Display version information.
 ```
 All commands are optional and can be run by purpose.
 

--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ CLI tool that checks versions of GitHub Actions that used in a repository. Pleas
 
 ## :shipit: Commands
 ```bash
-  --no-cache     (Default: false) Disable cache.
-  --no-colors    (Default: false) Disable colors.
-  --log-level    (Default: Information) Set log level. Possible values: Trace, Debug, Information, Warning, Error, Critical, None.
-  --output-type  (Default: Console) Information output type. Possible values: Console, Logger, Silent.
-  --repository   Path to the root of a project.
-  --token        GitHub token to work with actions repositories.
-  --upgrade      Upgrade versions to the latest one.
-  --help         Display this help screen.
-  --version      Display version information.
+--no-cache     Disable cache.
+--no-colors    Disable colors.
+--log-level    (Default: Information) Set log level. Possible values: Trace, Debug, Information, Warning, Error, Critical, None.
+--output-type  (Default: Console) Information output type. Possible values: Console, Logger, Silent.
+--repository   Path to the root of a project.
+--token        GitHub token to work with actions repositories.
+--upgrade      Upgrade versions to the latest one.
+--help         Display this help screen.
+--version      Display version information.
 ```
 All commands are optional and can be run by purpose.
 

--- a/src/Ghacu.Api/Entities/Action.cs
+++ b/src/Ghacu.Api/Entities/Action.cs
@@ -8,8 +8,8 @@ namespace Ghacu.Api.Entities
   {
     private const string DOCKER_PATTERN1 = "docker://(.+?)/(.+):(.+)";
     private const string DOCKER_PATTERN2 = "docker://(.+):(.+)";
-    private const string GITHUB_PATTERN = "(.+?)/(.+)@(.+)";
-    private const string INTERNAL_PATTERN = "(./)";
+    private const string GITHUB_PATTERN = "^(?!docker://)(.+?)/(.+)@(.+)";
+    private const string INTERNAL_PATTERN = "./";
 
     private Version _currentVersion;
     private Version _latestVersion;
@@ -55,8 +55,7 @@ namespace Ghacu.Api.Entities
           return;
         }
 
-        match = Regex.Match(actionName, INTERNAL_PATTERN);
-        Type = match.Success ? UsesType.Internal : UsesType.Unknown;
+        Type = Equals(actionName, INTERNAL_PATTERN) ? UsesType.Internal : UsesType.Unknown;
       }
 
       Initialize(null, actionName, null);

--- a/src/Ghacu.Api/IGlobalConfig.cs
+++ b/src/Ghacu.Api/IGlobalConfig.cs
@@ -1,7 +1,0 @@
-namespace Ghacu.Api
-{
-  public interface IGlobalConfig
-  {
-    public bool UseCache { get; }
-  }
-}

--- a/src/Ghacu.Api/Stream/IStreamer.cs
+++ b/src/Ghacu.Api/Stream/IStreamer.cs
@@ -5,5 +5,6 @@ namespace Ghacu.Api.Stream
     void Push<T>(StreamOptions options);
     void PushLine<T>(StreamOptions options);
     void PushEmpty();
+    void Clear(int numLines);
   }
 }

--- a/src/Ghacu.GitHub/GitHubClient.cs
+++ b/src/Ghacu.GitHub/GitHubClient.cs
@@ -11,8 +11,6 @@ namespace Ghacu.GitHub
     {
       OctokitClient = client;
     }
-    
-    internal Octokit.IGitHubClient OctokitClient { get; }
 
     public GitHubClient(string appName, string token)
     {
@@ -24,6 +22,8 @@ namespace Ghacu.GitHub
 
       OctokitClient = client;
     }
+
+    internal Octokit.IGitHubClient OctokitClient { get; }
 
     public async Task<string> GetLatestReleaseVersionAsync(string owner, string name)
     {

--- a/src/Ghacu.GitHub/GitHubClient.cs
+++ b/src/Ghacu.GitHub/GitHubClient.cs
@@ -7,12 +7,12 @@ namespace Ghacu.GitHub
 {
   public class GitHubClient : IGitHubClient
   {
-    private readonly Octokit.IGitHubClient _client;
-
     internal GitHubClient(Octokit.IGitHubClient client)
     {
-      _client = client;
+      OctokitClient = client;
     }
+    
+    internal Octokit.IGitHubClient OctokitClient { get; }
 
     public GitHubClient(string appName, string token)
     {
@@ -22,18 +22,18 @@ namespace Ghacu.GitHub
         client.Credentials = new Credentials(token);
       }
 
-      _client = client;
+      OctokitClient = client;
     }
 
     public async Task<string> GetLatestReleaseVersionAsync(string owner, string name)
     {
-      Release result = await _client.Repository.Release.GetLatest(owner, name);
+      Release result = await OctokitClient.Repository.Release.GetLatest(owner, name);
       return result.TagName;
     }
 
     public async Task<string> GetLatestTagVersionAsync(string owner, string name)
     {
-      IReadOnlyList<RepositoryTag> allTags = await _client.Repository.GetAllTags(owner, name);
+      IReadOnlyList<RepositoryTag> allTags = await OctokitClient.Repository.GetAllTags(owner, name);
       return allTags?.LastOrDefault()?.Name;
     }
   }

--- a/src/Ghacu.GitHub/GitHubClient.cs
+++ b/src/Ghacu.GitHub/GitHubClient.cs
@@ -7,15 +7,22 @@ namespace Ghacu.GitHub
 {
   public class GitHubClient : IGitHubClient
   {
-    private readonly Octokit.GitHubClient _client;
+    private readonly Octokit.IGitHubClient _client;
+
+    internal GitHubClient(Octokit.IGitHubClient client)
+    {
+      _client = client;
+    }
 
     public GitHubClient(string appName, string token)
     {
-      _client = new Octokit.GitHubClient(new ProductHeaderValue(appName));
+      var client = new Octokit.GitHubClient(new ProductHeaderValue(appName));
       if (token != null)
       {
-        _client.Credentials = new Credentials(token);
+        client.Credentials = new Credentials(token);
       }
+
+      _client = client;
     }
 
     public async Task<string> GetLatestReleaseVersionAsync(string owner, string name)
@@ -27,7 +34,7 @@ namespace Ghacu.GitHub
     public async Task<string> GetLatestTagVersionAsync(string owner, string name)
     {
       IReadOnlyList<RepositoryTag> allTags = await _client.Repository.GetAllTags(owner, name);
-      return allTags.LastOrDefault()?.Name;
+      return allTags?.LastOrDefault()?.Name;
     }
   }
 }

--- a/src/Ghacu.GitHub/GitHubService.cs
+++ b/src/Ghacu.GitHub/GitHubService.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
 using Ghacu.Api;
 using Ghacu.Api.Entities;
 using Ghacu.Api.Stream;
@@ -8,6 +9,8 @@ using Ghacu.Api.Version;
 using Ghacu.GitHub.Exceptions;
 using Microsoft.Extensions.Logging;
 using GitHubAction = Ghacu.Api.Entities.Action;
+
+[assembly: InternalsVisibleTo("Ghacu.GitHub.Tests")]
 
 namespace Ghacu.GitHub
 {

--- a/src/Ghacu.GitHub/GitHubService.cs
+++ b/src/Ghacu.GitHub/GitHubService.cs
@@ -74,6 +74,15 @@ namespace Ghacu.GitHub
                     Messages = new StreamMessageBuilder().Add(e.Message, ConsoleColor.Yellow).Build()
                   });
                 }
+                catch (Exception e)
+                {
+                  _streamer.PushLine<GitHubService>(new StreamOptions
+                  {
+                    Exception = e,
+                    Level = LogLevel.Error,
+                    Messages = new StreamMessageBuilder().Add(e.Message, ConsoleColor.Red).Build()
+                  });
+                }
                 finally
                 {
                   _semaphore.Release();

--- a/src/Ghacu.Runner/Cli/BooleanOption.cs
+++ b/src/Ghacu.Runner/Cli/BooleanOption.cs
@@ -1,8 +1,0 @@
-namespace Ghacu.Runner.Cli
-{
-  public enum BooleanOption
-  {
-    Yes,
-    No
-  }
-}

--- a/src/Ghacu.Runner/Cli/CliService.cs
+++ b/src/Ghacu.Runner/Cli/CliService.cs
@@ -35,7 +35,7 @@ namespace Ghacu.Runner.Cli
       _workflowService = workflowService;
       _gitHubService = gitHubService;
       _printer = printer;
-      _progressBarFactory = progressBarFactory;
+      _progressBarFactory = progressBarFactory ?? (_ => null);
       _streamer = streamer;
       _gitHubService.RepositoryChecked += ProgressBarProcessed;
       _gitHubService.RepositoryCheckedStarted += ProgressBarPrepare;
@@ -44,9 +44,9 @@ namespace Ghacu.Runner.Cli
 
     private void ProgressBarPrepare(int totalTicks) => _progressBar = _progressBarFactory(totalTicks);
     
-    private void ProgressBarProcessed(RepositoryCheckedArgs args) => _progressBar.Report(args.ProgressValue);
+    private void ProgressBarProcessed(RepositoryCheckedArgs args) => _progressBar?.Report(args.ProgressValue);
 
-    private void ProgressBarDispose() => _progressBar.Dispose();
+    private void ProgressBarDispose() => _progressBar?.Dispose();
 
     /// <summary>
     /// Run GHACU logic on repository provided by user.
@@ -67,6 +67,16 @@ namespace Ghacu.Runner.Cli
           Exception = e,
           Level = LogLevel.Error,
           Messages = new StreamMessageBuilder().Add(e.Message, ConsoleColor.Red).Build()
+        });
+        return;
+      }
+      catch (Exception e)
+      {
+        _streamer.Push<CliService>(new StreamOptions
+        {
+          Exception = e,
+          Level = LogLevel.Critical,
+          Messages = new StreamMessageBuilder().Add(e.Message, ConsoleColor.DarkRed).Build()
         });
         return;
       }

--- a/src/Ghacu.Runner/Cli/Options.cs
+++ b/src/Ghacu.Runner/Cli/Options.cs
@@ -5,15 +5,15 @@ namespace Ghacu.Runner.Cli
 {
   public sealed class Options
   {
-    [Option("cache", Required = false, HelpText = "Enable cache.", Default = BooleanOption.Yes)]
-    public BooleanOption UseCache { get; set; }
+    [Option("no-cache", Required = false, HelpText = "Disable cache.", Default = false)]
+    public bool NoCache { get; set; }
 
-    [Option("color", Required = false, HelpText = "Enable colors.", Default = BooleanOption.Yes)]
-    public BooleanOption UseColors { get; set; }
+    [Option("no-colors", Required = false, HelpText = "Disable colors.", Default = false)]
+    public bool NoColors { get; set; }
 
     [Option("log-level", Required = false,
       HelpText = "Set log level. Possible values: Trace, Debug, Information, Warning, Error, Critical, None.",
-      Default = LogLevel.Error)]
+      Default = LogLevel.Information)]
     public LogLevel LogLevel { get; set; }
 
     [Option("output-type", Required = false,

--- a/src/Ghacu.Runner/Cli/Options.cs
+++ b/src/Ghacu.Runner/Cli/Options.cs
@@ -5,10 +5,10 @@ namespace Ghacu.Runner.Cli
 {
   public sealed class Options
   {
-    [Option("no-cache", Required = false, HelpText = "Disable cache.", Default = false)]
+    [Option("no-cache", Required = false, HelpText = "Disable cache.")]
     public bool NoCache { get; set; }
 
-    [Option("no-colors", Required = false, HelpText = "Disable colors.", Default = false)]
+    [Option("no-colors", Required = false, HelpText = "Disable colors.")]
     public bool NoColors { get; set; }
 
     [Option("log-level", Required = false,

--- a/src/Ghacu.Runner/Cli/Progress/PercentageProgressBar.cs
+++ b/src/Ghacu.Runner/Cli/Progress/PercentageProgressBar.cs
@@ -44,6 +44,7 @@ namespace Ghacu.Runner.Cli.Progress
     {
       // Make sure value is in [0..1] range
       value = Math.Max(0, Math.Min(1, value));
+      _currentTick++;
       Interlocked.Exchange(ref _currentProgress, value);
     }
 
@@ -61,7 +62,7 @@ namespace Ghacu.Runner.Cli.Progress
         string text = string.Format("[{0}{1}] [{2}/{3}] {4,5}% {5}",
           new string('#', progressBlockCount),
           new string('-', BLOCK_COUNT - progressBlockCount),
-          ++_currentTick,
+          _currentTick,
           _totalTicks,
           percent,
           ANIMATION[_animationIndex++ % ANIMATION.Length]);

--- a/src/Ghacu.Runner/Cli/Stream/ConsoleStreamer.cs
+++ b/src/Ghacu.Runner/Cli/Stream/ConsoleStreamer.cs
@@ -21,6 +21,18 @@ namespace Ghacu.Runner.Cli.Stream
     public void PushLine<T>(StreamOptions options) => PushInternal(Console.WriteLine, options);
 
     public void PushEmpty() => Console.WriteLine();
+    
+    public void Clear(int numLines)
+    {
+      for (var i = 0; i < numLines; i++)
+      {
+        Console.SetCursorPosition(0, Console.CursorTop - 1);
+        int currentLineCursor = Console.CursorTop;
+        Console.SetCursorPosition(0, Console.CursorTop);
+        Console.Write(new string(' ', Console.WindowWidth));
+        Console.SetCursorPosition(0, currentLineCursor);
+      }
+    }
 
     private void PushInternal(Action<string> push, StreamOptions options)
     {

--- a/src/Ghacu.Runner/Cli/Stream/LoggerStreamer.cs
+++ b/src/Ghacu.Runner/Cli/Stream/LoggerStreamer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 using Ghacu.Api.Stream;
 using Microsoft.Extensions.Logging;
@@ -25,5 +24,9 @@ namespace Ghacu.Runner.Cli.Stream
       string.Join(string.Empty, options.Messages.Select(m => m.Message)));
 
     public void PushEmpty() { }
+    
+    public void Clear(int numLines)
+    {
+    }
   }
 }

--- a/src/Ghacu.Runner/Cli/Stream/SilentStreamer.cs
+++ b/src/Ghacu.Runner/Cli/Stream/SilentStreamer.cs
@@ -15,5 +15,9 @@ namespace Ghacu.Runner.Cli.Stream
     public void PushEmpty()
     {
     }
+
+    public void Clear(int numLines)
+    {
+    }
   }
 }

--- a/src/Ghacu.Runner/Program.cs
+++ b/src/Ghacu.Runner/Program.cs
@@ -70,27 +70,27 @@ namespace Ghacu.Runner
             .AddLogging(b => b
               .AddConsole(options =>
               {
-                options.DisableColors = o.UseColors == BooleanOption.No;
+                options.DisableColors = o.NoColors;
                 options.Format = ConsoleLoggerFormat.Default;
               })
               .SetMinimumLevel(o.LogLevel));
 
-          if (o.UseCache == BooleanOption.Yes)
-          {
-            services.AddSingleton<ILatestVersionProvider, MemoryCacheVersionProvider>();
-          }
-          else
+          if (o.NoCache)
           {
             services.AddSingleton<ILatestVersionProvider, GitHubVersionProvider>();
           }
-          
-          if (o.UseColors == BooleanOption.Yes)
+          else
           {
-            services.AddTransient<IActionPrinter, ColorActionPrinter>();
+            services.AddSingleton<ILatestVersionProvider, MemoryCacheVersionProvider>();
+          }
+          
+          if (o.NoColors)
+          {
+            services.AddTransient<IActionPrinter, NoColorActionPrinter>();
           }
           else
           {
-            services.AddTransient<IActionPrinter, NoColorActionPrinter>();
+            services.AddTransient<IActionPrinter, ColorActionPrinter>();
           }
 
           using var container = new Container();

--- a/src/Ghacu.Runner/Program.cs
+++ b/src/Ghacu.Runner/Program.cs
@@ -62,7 +62,7 @@ namespace Ghacu.Runner
                 totalTicks => new GhacuShellProgressBar(totalTicks, serviceProvider.GetService<IConsoleStreamer>()),
                 totalTicks => new PercentageProgressBar(totalTicks, serviceProvider.GetService<IConsoleStreamer>())
               };
-              return dict[new Random().Next(0, dict.Length)];
+              return dict[new Random().Next(1, dict.Length)];
             })
             .AddTransient<IGitHubClient, GitHubClient>(
               _ => new GitHubClient(APP_NAME, o.GitHubToken ?? Environment.GetEnvironmentVariable(ENV_GITHUB_TOKEN)))

--- a/src/Ghacu.Runner/Program.cs
+++ b/src/Ghacu.Runner/Program.cs
@@ -59,7 +59,7 @@ namespace Ghacu.Runner
 
               var dict = new Func<int, IProgressBar>[]
               {
-                totalTicks => new GhacuShellProgressBar(totalTicks),
+                totalTicks => new GhacuShellProgressBar(totalTicks, serviceProvider.GetService<IConsoleStreamer>()),
                 totalTicks => new PercentageProgressBar(totalTicks, serviceProvider.GetService<IConsoleStreamer>())
               };
               return dict[new Random().Next(0, dict.Length)];

--- a/tests/Ghacu.Api.Tests/Ghacu.Api.Tests.csproj
+++ b/tests/Ghacu.Api.Tests/Ghacu.Api.Tests.csproj
@@ -24,6 +24,7 @@
         <PackageReference Include="coverlet.msbuild" Version="2.9.0" />
         <PackageReference Include="JustMock" Version="2020.2.616.1" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0-preview-20200519-01" />
+        <PackageReference Include="morelinq" Version="3.3.2" />
         <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164" />
         <PackageReference Include="xunit" Version="2.4.1" />
         <PackageReference Include="xunit.runner.visualstudio" Version="2.4.2" />

--- a/tests/Ghacu.Api.Tests/Stream/StreamMessageBuilderTest.cs
+++ b/tests/Ghacu.Api.Tests/Stream/StreamMessageBuilderTest.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ghacu.Api.Stream;
+using MoreLinq.Extensions;
+using Xunit;
+
+namespace Ghacu.Api.Tests.Stream
+{
+  public class StreamMessageBuilderTest
+  {
+    [Fact]
+    public void Build_Correctly()
+    {
+      var builder = new StreamMessageBuilder();
+      IEnumerable<StreamMessage> result = builder
+        .Add("test-message-1", (ConsoleColor)1)
+        .Add("test-message-2", (ConsoleColor)2)
+        .Add("test-message-3")
+        .Build();
+      Assert.NotNull(result);
+      Assert.Equal(3, result.Count());
+      result.ForEach((m, i) =>
+      {
+        if (i == 2)
+        {
+          Assert.Null(m.Color);
+        }
+        else
+        {
+          Assert.Equal((ConsoleColor)(i + 1), m.Color);
+        }
+
+        Assert.Equal($"test-message-{i + 1}", m.Message);
+      });
+    }
+  }
+}

--- a/tests/Ghacu.Api.Tests/Stream/StreamMessageTest.cs
+++ b/tests/Ghacu.Api.Tests/Stream/StreamMessageTest.cs
@@ -1,0 +1,24 @@
+using System;
+using Ghacu.Api.Stream;
+using Xunit;
+
+namespace Ghacu.Api.Tests.Stream
+{
+  public class StreamMessageTest
+  {
+    [Fact]
+    public void Test_GettersSetters()
+    {
+      var streamMessage = new StreamMessage();
+      Assert.Null(streamMessage.Color);
+      Assert.Null(streamMessage.Message);
+      
+      const ConsoleColor color = ConsoleColor.Cyan;
+      const string message = "test-message";
+      streamMessage.Color = color;
+      streamMessage.Message = message;
+      Assert.Equal(color, streamMessage.Color);
+      Assert.Equal(message, streamMessage.Message);
+    }
+  }
+}

--- a/tests/Ghacu.Api.Tests/Stream/StreamOptionsTest.cs
+++ b/tests/Ghacu.Api.Tests/Stream/StreamOptionsTest.cs
@@ -1,0 +1,35 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ghacu.Api.Stream;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Ghacu.Api.Tests.Stream
+{
+  public class StreamOptionsTest
+  {
+    [Fact]
+    public void Test_GettersSetters()
+    {
+      const LogLevel level = LogLevel.Critical;
+      var exception = new Exception("test-message");
+      var streamMessage1 = new StreamMessage();
+      var streamMessage2 = new StreamMessage();
+      var messages = new List<StreamMessage> { streamMessage1, streamMessage2 };
+      var options = new StreamOptions
+      {
+        Exception = exception,
+        Level = level,
+        Messages = messages
+      };
+      Assert.Same(exception, options.Exception);
+      Assert.Equal(level, options.Level);
+      Assert.NotNull(options.Messages);
+      Assert.Equal(2, options.Messages.Count());
+      Assert.Same(messages, options.Messages);
+      Assert.Contains(streamMessage1, options.Messages);
+      Assert.Contains(streamMessage2, options.Messages);
+    }
+  }
+}

--- a/tests/Ghacu.GitHub.Tests/GitHubClientTest.cs
+++ b/tests/Ghacu.GitHub.Tests/GitHubClientTest.cs
@@ -1,0 +1,100 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Octokit;
+using Telerik.JustMock;
+using Xunit;
+
+namespace Ghacu.GitHub.Tests
+{
+  public class GitHubClientTest
+  {
+    [Fact]
+    public async void GetLatestReleaseVersionAsync_Positive()
+    {
+      const string owner = "test-owner";
+      const string name = "test-name";
+      const string expected = "test-version";
+
+      var octokitRelease = new Release(
+        default,
+        default,
+        default,
+        default,
+        default,
+        default,
+        expected,
+        default,
+        default,
+        default,
+        default,
+        default,
+        default,
+        default(DateTimeOffset),
+        default,
+        default,
+        default,
+        new List<ReleaseAsset>());
+
+      var octokitReleaseClientMock = Mock.Create<IReleasesClient>();
+      Mock.Arrange(() => octokitReleaseClientMock.GetLatest(owner, name))
+        .Returns(Task.FromResult(octokitRelease));
+      
+      var octokitRepositoryMock = Mock.Create<IRepositoriesClient>();
+      Mock.Arrange(() => octokitRepositoryMock.Release).Returns(octokitReleaseClientMock);
+      
+      var octokitGitHubClientMock = Mock.Create<Octokit.IGitHubClient>();
+      Mock.Arrange(() => octokitGitHubClientMock.Repository).Returns(octokitRepositoryMock);
+      
+      var gitHubClient = new GitHubClient(octokitGitHubClientMock);
+      string actual = await gitHubClient.GetLatestReleaseVersionAsync(owner, name);
+      Assert.Equal(expected, actual);
+    }
+
+    [Theory]
+    [MemberData(nameof(DataGetLatestTagVersionAsyncPositive))]
+    public async void GetLatestTagVersionAsync_Positive(IReadOnlyList<RepositoryTag> tags, string expected)
+    {
+      const string owner = "test-owner";
+      const string name = "test-name";
+      
+      var octokitRepositoryMock = Mock.Create<IRepositoriesClient>();
+      Mock.Arrange(() => octokitRepositoryMock.GetAllTags(owner, name))
+        .Returns(Task.FromResult(tags));
+      
+      var octokitGitHubClientMock = Mock.Create<Octokit.IGitHubClient>();
+      Mock.Arrange(() => octokitGitHubClientMock.Repository).Returns(octokitRepositoryMock);
+      
+      var gitHubClient = new GitHubClient(octokitGitHubClientMock);
+      string actual = await gitHubClient.GetLatestTagVersionAsync(owner, name);
+      Assert.Equal(expected, actual);
+    }
+
+    public static IEnumerable<object[]> DataGetLatestTagVersionAsyncPositive => new List<object[]>
+    {
+      new object[]
+      {
+        new List<RepositoryTag>
+        {
+          new RepositoryTag(
+            "test-version-1", default, default, default, default),
+          new RepositoryTag(
+            "test-version-2", default, default, default, default),
+        },
+        "test-version-2"
+      },
+      new object[]
+      {
+        new List<RepositoryTag>
+        {
+          new RepositoryTag(
+            "test-version", default, default, default, default)
+        },
+        "test-version"
+      },
+      new object[] { new List<RepositoryTag>(), null },
+      new object[] { null, null },
+    };
+  }
+}

--- a/tests/Ghacu.GitHub.Tests/GitHubClientTest.cs
+++ b/tests/Ghacu.GitHub.Tests/GitHubClientTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Octokit;
 using Telerik.JustMock;
@@ -70,6 +71,7 @@ namespace Ghacu.GitHub.Tests
       Assert.Equal(expected, actual);
     }
 
+    [SuppressMessage("ReSharper", "SA1201")]
     public static IEnumerable<object[]> DataGetLatestTagVersionAsyncPositive => new List<object[]>
     {
       new object[]

--- a/tests/Ghacu.GitHub.Tests/GitHubClientTest.cs
+++ b/tests/Ghacu.GitHub.Tests/GitHubClientTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Octokit;
 using Telerik.JustMock;
@@ -94,7 +93,22 @@ namespace Ghacu.GitHub.Tests
         "test-version"
       },
       new object[] { new List<RepositoryTag>(), null },
-      new object[] { null, null },
+      new object[] { null, null }
     };
+
+    [Fact]
+    public void Create_Successfully()
+    {
+      const string appName = "test-app";
+      const string token = "test-token";
+      
+      var gitHubClient = new GitHubClient(appName, token);
+      Assert.IsType<Connection>(gitHubClient.OctokitClient.Connection);
+      var octokitConnection = gitHubClient.OctokitClient.Connection as Connection;
+      Assert.True(octokitConnection?.UserAgent.Contains(appName));
+      Assert.IsType<Octokit.GitHubClient>(gitHubClient.OctokitClient);
+      var octokitClient = gitHubClient.OctokitClient as Octokit.GitHubClient;
+      Assert.Equal(token, octokitClient.Credentials.GetToken());
+    }
   }
 }

--- a/tests/Ghacu.GitHub.Tests/GitHubServiceTest.cs
+++ b/tests/Ghacu.GitHub.Tests/GitHubServiceTest.cs
@@ -1,0 +1,222 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Ghacu.Api;
+using Ghacu.Api.Entities;
+using Ghacu.Api.Stream;
+using Ghacu.Api.Version;
+using Ghacu.GitHub.Exceptions;
+using Microsoft.Extensions.Logging;
+using Telerik.JustMock;
+using Xunit;
+using Action = Ghacu.Api.Entities.Action;
+
+namespace Ghacu.GitHub.Tests
+{
+  public class GitHubServiceTest
+  {
+    [Fact]
+    public void GetOutdated_Positive()
+    {
+      const int expectedTotalCount = 3;
+      const string owner1 = "own1";
+      const string repository1 = "repo1";
+      const string latestVersion1 = "v0.0.1-alpha.3+3465";
+      const string owner2 = "own2";
+      const string repository2 = "repo2";
+      const string currentVersion2 = "v1.0.0";
+      const string latestVersion2 = "v1.0.1";
+      const string owner3 = "own3";
+      const string repository3 = "repo3";
+      const string latestVersion3 = "v1";
+      
+      var providerMock = Mock.Create<ILatestVersionProvider>();
+      Mock.Arrange(() => providerMock.GetLatestVersionAsync(owner1, repository1))
+        .Returns(Task.FromResult(latestVersion1));
+      Mock.Arrange(() => providerMock.GetLatestVersionAsync(owner2, repository2))
+        .Returns(Task.FromResult(latestVersion2));
+      Mock.Arrange(() => providerMock.GetLatestVersionAsync(owner3, repository3))
+        .Returns(Task.FromResult(latestVersion3));
+
+      var semaphore = new SemaphoreSlim(1, 1);
+      var semaphoreProxyMock = Mock.Create<ISemaphoreSlimProxy>();
+      Mock.Arrange(() => semaphoreProxyMock.WaitAsync())
+        .Returns(() => semaphore.WaitAsync()).Occurs(expectedTotalCount);
+      Mock.Arrange(() => semaphoreProxyMock.Release())
+        .Returns(() => semaphore.Release()).Occurs(expectedTotalCount);
+      
+      var streamerMock = Mock.Create<IStreamer>();
+
+      var gitHubService = new GitHubService(providerMock, semaphoreProxyMock, streamerMock);
+      
+      var repositoryChecked = 0;
+      gitHubService.RepositoryChecked += args =>
+      {
+        ++repositoryChecked;
+        Assert.Equal((double)repositoryChecked / expectedTotalCount, args.ProgressValue);
+      };
+      var repositoryCheckedStarted = 0;
+      gitHubService.RepositoryCheckedStarted += actualTotalCount =>
+      {
+        repositoryCheckedStarted++;
+        Assert.Equal(expectedTotalCount, actualTotalCount);
+      };
+      var repositoryCheckedFinished = 0;
+      gitHubService.RepositoryCheckedFinished += () =>
+      {
+        repositoryCheckedFinished++;
+      };
+      var workflowInfos = new List<WorkflowInfo>
+      {
+        new WorkflowInfo(default, new ActionWorkflow
+        {
+          Jobs = new Dictionary<string, Job>
+          {
+            {
+              "job-1",
+              new Job
+              {
+                Steps = new List<Step>
+                {
+                  new Step { Uses = $"docker://{owner1}/{repository1}:v0.0.1-alpha.3+3465" },
+                  new Step { Uses = $"{owner2}/{repository2}@{currentVersion2}" },
+                  new Step { Uses = "./" },
+                }
+              }
+            },
+            {
+              "job-2",
+              new Job
+              {
+                Steps = new List<Step>
+                {
+                  new Step { Uses = $"docker://{owner3}/{repository3}:v2" },
+                  new Step { Uses = null },
+                }
+              }
+            }
+          }
+        })
+      };
+      IDictionary<WorkflowInfo, IEnumerable<Action>> actual = gitHubService.GetOutdated(workflowInfos);
+      Assert.Single(actual);
+      Assert.True(actual.ContainsKey(workflowInfos[0]));
+      IEnumerable<Action> actions = actual[workflowInfos[0]];
+      Assert.Single(actions);
+      Action action = actions.Single();
+      Assert.Equal(owner2, action.Owner);
+      Assert.Equal(repository2, action.Repository);
+      Assert.Equal(currentVersion2, action.CurrentVersion);
+      Assert.Equal(latestVersion2, action.LatestVersion);
+
+      Assert.Equal(1, repositoryCheckedStarted);
+      Assert.Equal(expectedTotalCount, repositoryChecked);
+      Assert.Equal(1, repositoryCheckedFinished);
+      
+      Mock.Assert(providerMock);
+      Mock.Assert(semaphoreProxyMock);
+      Mock.Assert(streamerMock);
+    }
+
+    [Theory]
+    [MemberData(nameof(DataGetOutdatedGetLatestVersionAsyncThrows))]
+    public void GetOutdated_GetLatestVersionAsync_Throws(
+      Exception expectedException, LogLevel expectedLevel, ConsoleColor expectedColor)
+    {
+      const int expectedTotalCount = 1;
+      const string owner1 = "own1";
+      const string repository1 = "repo1";
+      
+      var providerMock = Mock.Create<ILatestVersionProvider>();
+      Mock.Arrange(() => providerMock.GetLatestVersionAsync(owner1, repository1))
+        .Throws(expectedException);
+
+      var semaphoreProxyMock = Mock.Create<ISemaphoreSlimProxy>();
+      Mock.Arrange(() => semaphoreProxyMock.WaitAsync())
+        .Returns(Task.CompletedTask).Occurs(expectedTotalCount);
+      Mock.Arrange(() => semaphoreProxyMock.Release())
+        .Returns(1 /* any int */).Occurs(expectedTotalCount);
+      
+      var streamerMock = Mock.Create<IStreamer>();
+      Mock.Arrange(() => streamerMock.PushLine<GitHubService>(
+        Arg.Matches<StreamOptions>(options =>
+          ReferenceEquals(expectedException, options.Exception)
+          && options.Level == expectedLevel
+          && options.Messages.Count() == 1
+          && options.Messages.Single().Color == expectedColor
+          && options.Messages.Single().Message == expectedException.Message)))
+        .Occurs(expectedTotalCount);
+
+      var gitHubService = new GitHubService(providerMock, semaphoreProxyMock, streamerMock);
+      
+      var repositoryChecked = 0;
+      gitHubService.RepositoryChecked += args =>
+      {
+        ++repositoryChecked;
+        Assert.Equal((double)repositoryChecked / expectedTotalCount, args.ProgressValue);
+      };
+      var repositoryCheckedStarted = 0;
+      gitHubService.RepositoryCheckedStarted += actualTotalCount =>
+      {
+        repositoryCheckedStarted++;
+        Assert.Equal(expectedTotalCount, actualTotalCount);
+      };
+      var repositoryCheckedFinished = 0;
+      gitHubService.RepositoryCheckedFinished += () =>
+      {
+        repositoryCheckedFinished++;
+      };
+      var workflowInfos = new List<WorkflowInfo>
+      {
+        new WorkflowInfo(default, new ActionWorkflow
+        {
+          Jobs = new Dictionary<string, Job>
+          {
+            {
+              "job-1",
+              new Job
+              {
+                Steps = new List<Step>
+                {
+                  new Step { Uses = $"docker://{owner1}/{repository1}:v0.0.1-alpha.3+3465" },
+                  new Step { Uses = "./" },
+                }
+              }
+            },
+            {
+              "job-2",
+              new Job
+              {
+                Steps = new List<Step>
+                {
+                  new Step { Uses = null },
+                }
+              }
+            }
+          }
+        })
+      };
+      IDictionary<WorkflowInfo, IEnumerable<Action>> actual = gitHubService.GetOutdated(workflowInfos);
+      Assert.Empty(actual);
+
+      Assert.Equal(1, repositoryCheckedStarted);
+      Assert.Equal(expectedTotalCount, repositoryChecked);
+      Assert.Equal(1, repositoryCheckedFinished);
+      
+      Mock.Assert(providerMock);
+      Mock.Assert(semaphoreProxyMock);
+      Mock.Assert(streamerMock);
+    }
+
+    public static IEnumerable<object[]> DataGetOutdatedGetLatestVersionAsyncThrows => new List<object[]>
+    {
+      new object[]
+      {
+        new GitHubVersionNotFoundException("test-exception-message"), LogLevel.Warning, ConsoleColor.Yellow
+      },
+      new object[] { new Exception("test-exception-message"), LogLevel.Error, ConsoleColor.Red }
+    };
+  }
+}

--- a/tests/Ghacu.GitHub.Tests/GitHubServiceTest.cs
+++ b/tests/Ghacu.GitHub.Tests/GitHubServiceTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
@@ -210,6 +211,7 @@ namespace Ghacu.GitHub.Tests
       Mock.Assert(streamerMock);
     }
 
+    [SuppressMessage("ReSharper", "SA1201")]
     public static IEnumerable<object[]> DataGetOutdatedGetLatestVersionAsyncThrows => new List<object[]>
     {
       new object[]

--- a/tests/Ghacu.Runner.Tests/Cli/CliServiceTest.cs
+++ b/tests/Ghacu.Runner.Tests/Cli/CliServiceTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Ghacu.Api.Entities;
 using Ghacu.Api.Stream;
@@ -128,6 +129,7 @@ namespace Ghacu.Runner.Tests.Cli
       Mock.Assert(streamerMock);
     }
     
+    [SuppressMessage("ReSharper", "SA1201")]
     public static IEnumerable<object[]> DataRunGetWorkflowsError => new List<object[]>
     {
       new object[] { new WorkflowValidationException("exception-message"), LogLevel.Error, ConsoleColor.Red },
@@ -193,6 +195,7 @@ namespace Ghacu.Runner.Tests.Cli
       Assert.Equal(expectedNumCalls, actualNumCalls[0]);
     }
     
+    [SuppressMessage("ReSharper", "SA1201")]
     public static IEnumerable<object[]> DataDisposePositiveWithoutProgressBar => new List<object[]>
     {
       new object[]
@@ -204,7 +207,7 @@ namespace Ghacu.Runner.Tests.Cli
           return null;
         }), 1
       },
-      new object[] { new Func<int, int[], Func<int, IProgressBar>>((_1, _2) => null), 0 }
+      new object[] { new Func<int, int[], Func<int, IProgressBar>>((arg1, arg2) => null), 0 }
     };
   } 
 }

--- a/tests/Ghacu.Runner.Tests/Cli/CliServiceTest.cs
+++ b/tests/Ghacu.Runner.Tests/Cli/CliServiceTest.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Ghacu.Api.Entities;
+using Ghacu.Api.Stream;
+using Ghacu.GitHub;
+using Ghacu.Runner.Cli;
+using Ghacu.Runner.Cli.Print;
+using Ghacu.Runner.Cli.Progress;
+using Ghacu.Workflow;
+using Ghacu.Workflow.Exceptions;
+using Microsoft.Extensions.Logging;
+using Telerik.JustMock;
+using Telerik.JustMock.Expectations.Abstraction;
+using Xunit;
+using GitHubAction = Ghacu.Api.Entities.Action;
+
+namespace Ghacu.Runner.Tests.Cli
+{
+  public class CliServiceTest
+  {
+    [Theory]
+    [InlineData(true, true)]
+    [InlineData(false, true)]
+    [InlineData(true, false)]
+    [InlineData(false, false)]
+    public void Run_ShouldUpgrade(bool shouldUpgrade, bool isOutdatedEmpty)
+    {
+      const string repository = "test-repository";
+
+      IEnumerable<WorkflowInfo> infos = new List<WorkflowInfo>();
+      var workflowServiceMock = Mock.Create<IWorkflowService>();
+      Mock.Arrange(() => workflowServiceMock.GetWorkflows(repository)).Returns(infos);
+
+      IDictionary<WorkflowInfo, IEnumerable<GitHubAction>> outdated;
+      var actionPrinterMock = Mock.Create<IActionPrinter>();
+      if (isOutdatedEmpty)
+      {
+        outdated = new Dictionary<WorkflowInfo, IEnumerable<GitHubAction>>();
+        Mock.Arrange(() => actionPrinterMock.PrintHeader(Arg.AnyString, Arg.AnyString))
+          .OccursNever();
+        Mock.Arrange(() => actionPrinterMock.Print(Arg.IsAny<IEnumerable<GitHubAction>>()))
+          .OccursNever();
+        Mock.Arrange(() => actionPrinterMock.PrintNoUpgradeNeeded()).DoNothing().OccursOnce();
+      }
+      else
+      {
+        const string fileName = ".github/test-file";
+        var actionWorkflow = new ActionWorkflow { Name = "test-action-workflow-name" };
+        var actions = new List<GitHubAction>();
+        outdated = new Dictionary<WorkflowInfo, IEnumerable<GitHubAction>>
+        {
+          { new WorkflowInfo($"some-folder/{fileName}", actionWorkflow), actions }
+        };
+        Mock.Arrange(() => actionPrinterMock.PrintHeader(actionWorkflow.Name, fileName))
+          .DoNothing().OccursOnce();
+        Mock.Arrange(() => actionPrinterMock.Print(actions))
+          .DoNothing().OccursOnce();
+        Mock.Arrange(() => actionPrinterMock.PrintNoUpgradeNeeded()).OccursNever();
+      }
+
+      var gitHubServiceMock = Mock.Create<IGitHubService>();
+      Mock.Arrange(() => gitHubServiceMock.GetOutdated(infos)).Returns(outdated);
+      
+      var progressBarMock = Mock.Create<Ghacu.Runner.Cli.Progress.IProgressBar>();
+      Mock.Arrange(() => progressBarMock.Report(0.25)).DoNothing().OccursOnce();
+      Mock.Arrange(() => progressBarMock.Dispose()).DoNothing().OccursOnce();
+
+      var streamerMock = Mock.Create<IStreamer>();
+      Mock.Arrange(() => streamerMock.Push<CliService>(Arg.IsAny<StreamOptions>())).OccursNever();
+
+      IAssertable pushEmptySetup = Mock.Arrange(() => streamerMock.PushEmpty()).DoNothing();
+      IAssertable runUpgradeSetup = Mock.Arrange(() => actionPrinterMock.PrintRunUpgrade()).DoNothing();
+      if (isOutdatedEmpty)
+      {
+        pushEmptySetup.OccursNever();
+        runUpgradeSetup.OccursNever();
+      }
+      else if (!shouldUpgrade)
+      {
+        pushEmptySetup.OccursOnce();
+        runUpgradeSetup.OccursOnce();
+      }
+      
+      var service = new CliService(
+        workflowServiceMock, gitHubServiceMock, actionPrinterMock, null, streamerMock);
+      service.Run(repository, shouldUpgrade);
+      
+      Mock.Assert(workflowServiceMock);
+      Mock.Assert(gitHubServiceMock);
+      Mock.Assert(actionPrinterMock);
+      Mock.Assert(streamerMock);
+    }
+
+    [Theory]
+    [MemberData(nameof(DataRunGetWorkflowsError))]
+    public void Run_GetWorkflows_Error(
+      Exception expectedException, LogLevel expectedLogLevel, ConsoleColor expectedColor)
+    {
+      const string repository = "test-repository";
+      var workflowServiceMock = Mock.Create<IWorkflowService>();
+      Mock.Arrange(() => workflowServiceMock.GetWorkflows(repository)).Throws(expectedException);
+      var gitHubServiceMock = Mock.Create<IGitHubService>();
+      Mock.Arrange(() => gitHubServiceMock.GetOutdated(Arg.IsAny<IEnumerable<WorkflowInfo>>()));
+      var actionPrinterMock = Mock.Create<IActionPrinter>();
+      Mock.Arrange(() => actionPrinterMock.PrintHeader(Arg.AnyString, Arg.AnyString))
+        .OccursNever();
+      Mock.Arrange(() => actionPrinterMock.Print(Arg.IsAny<IEnumerable<GitHubAction>>())).OccursNever();
+      Mock.Arrange(() => actionPrinterMock.PrintNoUpgradeNeeded()).OccursNever();
+      Mock.Arrange(() => actionPrinterMock.PrintRunUpgrade()).OccursNever();
+      var streamerMock = Mock.Create<IStreamer>();
+      Mock.Arrange(() => streamerMock.Push<CliService>(Arg.Matches<StreamOptions>(options =>
+        ReferenceEquals(expectedException, options.Exception)
+          && options.Level == expectedLogLevel
+          && options.Messages.Count() == 1
+          && options.Messages.Single().Color == expectedColor
+          && options.Messages.Single().Message == expectedException.Message)))
+        .DoNothing()
+        .OccursOnce();
+      Mock.Arrange(() => streamerMock.PushEmpty()).OccursNever();
+      var service = new CliService(
+        workflowServiceMock, gitHubServiceMock, actionPrinterMock, null, streamerMock);
+      service.Run(repository, false /* any boolean */);
+      
+      Mock.Assert(workflowServiceMock);
+      Mock.Assert(gitHubServiceMock);
+      Mock.Assert(actionPrinterMock);
+      Mock.Assert(streamerMock);
+    }
+    
+    public static IEnumerable<object[]> DataRunGetWorkflowsError => new List<object[]>
+    {
+      new object[] { new WorkflowValidationException("exception-message"), LogLevel.Error, ConsoleColor.Red },
+      new object[] { new Exception("exception-message"), LogLevel.Critical, ConsoleColor.DarkRed }
+    };
+
+    [Fact]
+    public void Dispose_Positive_WithProgressBar()
+    {
+      const int index = 1;
+      const int expectedTotalTicks = 5;
+      var gitHubServiceMock = Mock.Create<IGitHubService>();
+
+      var progressBarMock = Mock.Create<IProgressBar>();
+      Mock.Arrange(() => progressBarMock.Report((double)index / expectedTotalTicks)).DoNothing().OccursOnce();
+      Mock.Arrange(() => progressBarMock.Dispose()).DoNothing().Occurs(2);
+
+      var createProgressBarTotalCalls = 0;
+      IProgressBar CreateProgressBar(int actualTotalTicks)
+      {
+        createProgressBarTotalCalls++;
+        Assert.Equal(expectedTotalTicks, actualTotalTicks);
+        return progressBarMock;
+      }
+      
+      var service = new CliService(
+        null, gitHubServiceMock, null, CreateProgressBar, null);
+      Mock.Raise(() => gitHubServiceMock.RepositoryCheckedStarted += null, expectedTotalTicks);
+      Mock.Raise(() => gitHubServiceMock.RepositoryChecked += null, new RepositoryCheckedArgs(index, expectedTotalTicks));
+      Mock.Raise(() => gitHubServiceMock.RepositoryCheckedFinished += null);
+      service.Dispose();
+      Mock.Raise(() => gitHubServiceMock.RepositoryCheckedStarted += null, expectedTotalTicks);
+      Mock.Raise(() => gitHubServiceMock.RepositoryChecked += null, new RepositoryCheckedArgs(index, expectedTotalTicks));
+      Mock.Raise(() => gitHubServiceMock.RepositoryCheckedFinished += null);
+      
+      Assert.Equal(1, createProgressBarTotalCalls);
+      Mock.Assert(progressBarMock);
+    }
+
+    [Theory]
+    [MemberData(nameof(DataDisposePositiveWithoutProgressBar))]
+    public void Dispose_Positive_WithoutProgressBar(
+      Func<int, int[], Func<int, IProgressBar>> factoryOfProgressBarFactory, int expectedNumCalls)
+    {
+      const int index = 1;
+      const int expectedTotalTicks = 5;
+      var gitHubServiceMock = Mock.Create<IGitHubService>();
+      var actualNumCalls = new[] { 0 };
+      var service = new CliService(
+        null,
+        gitHubServiceMock,
+        null,
+        factoryOfProgressBarFactory(expectedTotalTicks, actualNumCalls),
+        null);
+      Mock.Raise(() => gitHubServiceMock.RepositoryCheckedStarted += null, expectedTotalTicks);
+      Mock.Raise(() => gitHubServiceMock.RepositoryChecked += null, new RepositoryCheckedArgs(index, expectedTotalTicks));
+      Mock.Raise(() => gitHubServiceMock.RepositoryCheckedFinished += null);
+      service.Dispose();
+      Mock.Raise(() => gitHubServiceMock.RepositoryCheckedStarted += null, expectedTotalTicks);
+      Mock.Raise(() => gitHubServiceMock.RepositoryChecked += null, new RepositoryCheckedArgs(index, expectedTotalTicks));
+      Mock.Raise(() => gitHubServiceMock.RepositoryCheckedFinished += null);
+      
+      Assert.Equal(expectedNumCalls, actualNumCalls[0]);
+    }
+    
+    public static IEnumerable<object[]> DataDisposePositiveWithoutProgressBar => new List<object[]>
+    {
+      new object[]
+      {
+        new Func<int, int[], Func<int, IProgressBar>>((expected, numCalls) => actual =>
+        {
+          numCalls[0]++;
+          Assert.Equal(expected, actual);
+          return null;
+        }), 1
+      },
+      new object[] { new Func<int, int[], Func<int, IProgressBar>>((_1, _2) => null), 0 }
+    };
+  } 
+}

--- a/tests/Ghacu.Runner.Tests/Cli/OptionsTest.cs
+++ b/tests/Ghacu.Runner.Tests/Cli/OptionsTest.cs
@@ -33,35 +33,35 @@ namespace Ghacu.Runner.Tests.Cli
       Assert.Equal(
         "Set log level. Possible values: Trace, Debug, Information, Warning, Error, Critical, None.",
         option.HelpText);
-      Assert.Equal(LogLevel.Error, option.Default);
+      Assert.Equal(LogLevel.Information, option.Default);
     }
 
     [Fact]
-    public void UseCache_ConfiguredCorrectly()
+    public void NoCache_ConfiguredCorrectly()
     {
-      object[] attrs = typeof(Options).GetProperty("UseCache")?.GetCustomAttributes(typeof(OptionAttribute), false);
+      object[] attrs = typeof(Options).GetProperty("NoCache")?.GetCustomAttributes(typeof(OptionAttribute), false);
       Assert.NotNull(attrs);
       Assert.Single(attrs);
       var option = attrs[0] as OptionAttribute;
       Assert.NotNull(option);
-      Assert.Equal("cache", option.LongName);
+      Assert.Equal("no-cache", option.LongName);
       Assert.False(option.Required);
-      Assert.Equal("Enable cache.", option.HelpText);
-      Assert.Equal(BooleanOption.Yes, option.Default);
+      Assert.Equal("Disable cache.", option.HelpText);
+      Assert.Equal(false, option.Default);
     }
 
     [Fact]
-    public void UseColors_ConfiguredCorrectly()
+    public void NoColors_ConfiguredCorrectly()
     {
-      object[] attrs = typeof(Options).GetProperty("UseColors")?.GetCustomAttributes(typeof(OptionAttribute), false);
+      object[] attrs = typeof(Options).GetProperty("NoColors")?.GetCustomAttributes(typeof(OptionAttribute), false);
       Assert.NotNull(attrs);
       Assert.Single(attrs);
       var option = attrs[0] as OptionAttribute;
       Assert.NotNull(option);
-      Assert.Equal("color", option.LongName);
+      Assert.Equal("no-colors", option.LongName);
       Assert.False(option.Required);
-      Assert.Equal("Enable colors.", option.HelpText);
-      Assert.Equal(BooleanOption.Yes, option.Default);
+      Assert.Equal("Disable colors.", option.HelpText);
+      Assert.Equal(false, option.Default);
     }
 
     [Fact]
@@ -81,9 +81,9 @@ namespace Ghacu.Runner.Tests.Cli
       options.LogLevel = expectedLogLevel;
       Assert.Equal(expectedLogLevel, options.LogLevel);
 
-      const BooleanOption expectedUseCache = BooleanOption.Yes;
-      options.UseCache = expectedUseCache;
-      Assert.Equal(expectedUseCache, options.UseCache);
+      const bool expectedNoCache = true;
+      options.NoCache = expectedNoCache;
+      Assert.Equal(expectedNoCache, options.NoCache);
 
       const string expectedGitHubToken = "SomeToken";
       options.GitHubToken = expectedGitHubToken;
@@ -93,9 +93,9 @@ namespace Ghacu.Runner.Tests.Cli
       options.OutputType = outputType;
       Assert.Equal(outputType, options.OutputType);
 
-      const BooleanOption useColors = BooleanOption.No;
-      options.UseColors = useColors;
-      Assert.Equal(useColors, options.UseColors);
+      const bool expectedNoColors = true;
+      options.NoColors = expectedNoColors;
+      Assert.Equal(expectedNoColors, options.NoColors);
     }
 
     [Fact]

--- a/tests/Ghacu.Runner.Tests/Cli/OptionsTest.cs
+++ b/tests/Ghacu.Runner.Tests/Cli/OptionsTest.cs
@@ -47,7 +47,7 @@ namespace Ghacu.Runner.Tests.Cli
       Assert.Equal("no-cache", option.LongName);
       Assert.False(option.Required);
       Assert.Equal("Disable cache.", option.HelpText);
-      Assert.Equal(false, option.Default);
+      Assert.Null(option.Default);
     }
 
     [Fact]
@@ -61,7 +61,7 @@ namespace Ghacu.Runner.Tests.Cli
       Assert.Equal("no-colors", option.LongName);
       Assert.False(option.Required);
       Assert.Equal("Disable colors.", option.HelpText);
-      Assert.Equal(false, option.Default);
+      Assert.Null(option.Default);
     }
 
     [Fact]

--- a/tests/Ghacu.Runner.Tests/Cli/Progress/GhacuShellProgressBarTest.cs
+++ b/tests/Ghacu.Runner.Tests/Cli/Progress/GhacuShellProgressBarTest.cs
@@ -1,0 +1,61 @@
+using System;
+using Ghacu.Api.Stream;
+using Ghacu.Runner.Cli.Progress;
+using Telerik.JustMock;
+using Xunit;
+
+namespace Ghacu.Runner.Tests.Cli.Progress
+{
+  public class GhacuShellProgressBarTest
+  {
+    [Fact]
+    public void Create_Successfully()
+    {
+      const int totalTicks = 3;
+      var progressBar = new GhacuShellProgressBar(totalTicks, null);
+      Assert.Equal($"[0/{totalTicks}]", progressBar.ProgressBar.Message);
+      Assert.Equal(totalTicks, progressBar.ProgressBar.MaxTicks);
+    }
+
+    [Fact]
+    public void Tick_Positive()
+    {
+      const int currentTick = 12;
+      const int maxTicks = 34;
+      var shellProgressBarMock = Mock.Create<ShellProgressBar.IProgressBar>();
+      Mock.Arrange(() => shellProgressBarMock.CurrentTick).Returns(currentTick);
+      Mock.Arrange(() => shellProgressBarMock.MaxTicks).Returns(maxTicks);
+      Mock.Arrange(() => shellProgressBarMock.Tick($"[{currentTick + 1}/{maxTicks}]"))
+        .DoNothing().OccursOnce();
+
+      var progressBar = new GhacuShellProgressBar(null, options =>
+      {
+        Assert.True(options.CollapseWhenFinished);
+        Assert.True(options.DisplayTimeInRealTime);
+        Assert.Equal('#', options.ProgressCharacter);
+        Assert.True(options.ProgressBarOnBottom);
+        Assert.True(options.ShowEstimatedDuration);
+        Assert.Equal(Console.ForegroundColor, options.ForegroundColor);
+        Assert.Equal('-', options.BackgroundCharacter);
+        return shellProgressBarMock;
+      });
+      Assert.Equal(shellProgressBarMock, progressBar.ProgressBar);
+      progressBar.Report(-2.1 /* any double */);
+      
+      Mock.Assert(shellProgressBarMock);
+    }
+
+    [Fact]
+    public void Dispose_Positive()
+    {
+      var shellProgressBarMock = Mock.Create<ShellProgressBar.IProgressBar>();
+      Mock.Arrange(() => shellProgressBarMock.Dispose()).DoNothing().OccursOnce();
+      var streamerMock = Mock.Create<IStreamer>();
+      Mock.Arrange(() => streamerMock.Clear(2)).DoNothing().OccursOnce();
+      var progressBar = new GhacuShellProgressBar(streamerMock, _ => shellProgressBarMock);
+      progressBar.Dispose();
+      Mock.Assert(shellProgressBarMock);
+      Mock.Assert(streamerMock);
+    }
+  }
+}

--- a/tests/Ghacu.Runner.Tests/Cli/Stream/LoggerStreamerTest.cs
+++ b/tests/Ghacu.Runner.Tests/Cli/Stream/LoggerStreamerTest.cs
@@ -1,0 +1,96 @@
+using System;
+using System.Collections.Generic;
+using Ghacu.Api.Stream;
+using Ghacu.Runner.Cli.Stream;
+using Microsoft.Extensions.Logging;
+using Xunit;
+
+namespace Ghacu.Runner.Tests.Cli.Stream
+{
+  public class LoggerStreamerTest
+  {
+    [Fact]
+    public void Push_Successful() =>
+      RunSuccessfulTest((streamer, options) => streamer.Push<LoggerStreamerTest>(options));
+    
+    [Fact]
+    public void PushLine_Successful() =>
+      RunSuccessfulTest((streamer, options) => streamer.PushLine<LoggerStreamerTest>(options));
+
+    private static void RunSuccessfulTest(Action<IStreamer, StreamOptions> runner)
+    {
+      const string message1 = "test-";
+      const string message2 = "message";
+      const LogLevel logLevel = LogLevel.Debug;
+      var expectedException = new Exception("test-exception-message");
+      var stubLogger = new StubLogger(logLevel, expectedException, message1 + message2);
+      var streamer = new LoggerStreamer(new StubLoggerFactory(stubLogger));
+      runner(streamer, new StreamOptions
+      {
+        Level = logLevel,
+        Exception = expectedException,
+        Messages = new List<StreamMessage>
+        {
+          new StreamMessage { Message = message1 },
+          new StreamMessage { Message = message2 }
+        }
+      });
+      Assert.Equal(1, stubLogger.NumCalls);
+    }
+
+    [Fact]
+    public void PushEmpty_Successful() => new LoggerStreamer(null).PushEmpty();
+
+    [Fact]
+    public void Clear_Successful() => new LoggerStreamer(null).Clear(3 /* any int */);
+  }
+
+  internal class StubLoggerFactory : ILoggerFactory
+  {
+    private readonly ILogger _logger;
+
+    internal StubLoggerFactory(ILogger logger)
+    {
+      _logger = logger;
+    }
+    
+    public void Dispose()
+    {
+    }
+
+    public ILogger CreateLogger(string categoryName) => _logger;
+
+    public void AddProvider(ILoggerProvider provider)
+    {
+    }
+  }
+
+  internal class StubLogger : ILogger
+  {
+    private readonly LogLevel _expectedLogLevel;
+    private readonly Exception _expectedException;
+    private readonly string _expectedMessage;
+
+    internal StubLogger(LogLevel expectedLogLevel, Exception expectedException, string expectedMessage)
+    {
+      _expectedLogLevel = expectedLogLevel;
+      _expectedException = expectedException;
+      _expectedMessage = expectedMessage;
+    }
+
+    internal int NumCalls { get; private set; }
+
+    public void Log<TState>(
+      LogLevel logLevel, EventId eventId, TState state, Exception exception, Func<TState, Exception, string> formatter)
+    {
+      NumCalls++;
+      Assert.Equal(_expectedLogLevel, logLevel);
+      Assert.Equal(_expectedException, exception);
+      Assert.Equal(_expectedMessage, formatter(state, exception));
+    }
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public IDisposable BeginScope<TState>(TState state) => null;
+  }
+}

--- a/tests/Ghacu.Runner.Tests/Cli/Stream/SilentStreamerTest.cs
+++ b/tests/Ghacu.Runner.Tests/Cli/Stream/SilentStreamerTest.cs
@@ -1,0 +1,21 @@
+using Ghacu.Api.Stream;
+using Ghacu.Runner.Cli.Stream;
+using Xunit;
+
+namespace Ghacu.Runner.Tests.Cli.Stream
+{
+  public class SilentStreamerTest
+  {
+    [Fact]
+    public void Push_Successful() => new SilentStreamer().Push<int>(new StreamOptions());
+    
+    [Fact]
+    public void PushLine_Successful() => new SilentStreamer().PushLine<string>(new StreamOptions());
+    
+    [Fact]
+    public void PushEmpty_Successful() => new SilentStreamer().PushEmpty();
+    
+    [Fact]
+    public void Clear_Successful() => new SilentStreamer().Clear(1 /* any int */);
+  }
+}

--- a/tests/Ghacu.Runner.Tests/Ghacu.Runner.Tests.csproj
+++ b/tests/Ghacu.Runner.Tests/Ghacu.Runner.Tests.csproj
@@ -22,6 +22,7 @@
     <ItemGroup>
       <PackageReference Include="coverlet.collector" Version="1.3.0" />
       <PackageReference Include="coverlet.msbuild" Version="2.9.0" />
+      <PackageReference Include="JustMock" Version="2020.2.616.1" />
       <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.0-preview-20200519-01" />
       <PackageReference Include="StyleCop.Analyzers" Version="1.2.0-beta.164" />
       <PackageReference Include="xunit" Version="2.4.1" />


### PR DESCRIPTION
<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->
Closes #50 

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] I have read the [CONTRIBUTING](https://github.com/fabasoad/ghacu/CONTRIBUTING.md) doc.
- [x] Tests for the changes have been added (for bug fixes / features).
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features).
- [x] Build (`dotnet build`) was run locally and any changes were pushed for failures / warnings.
- [x] Tests (`dotnet test`) has passed locally and any fixes were made for failures.

## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
Tests coverage < 50%

## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->
Tests coverage is 70%

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information
N/A
<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
<!-- This document was adapted from the open-source [appium/appium](https://github.com/appium/appium/blob/master/.github/PULL_REQUEST_TEMPLATE.md) repository. -->
